### PR TITLE
Fix hero video switch glitch and showcase tracking features

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
             <p class="subtle">Now available on iOS. Android in exploration.</p>
           </div>
           <div class="hero__visual">
-            <video class="hero-video" src="assets/video/iPhone1.mp4" autoplay muted playsinline preload="auto" aria-label="Time Farm app preview"></video>
+            <video class="hero-video" src="assets/video/iPhone1.mp4" width="1206" height="2622" poster="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjA2IiBoZWlnaHQ9IjI2MjIiPjxyZWN0IHdpZHRoPSIxMjA2IiBoZWlnaHQ9IjI2MjIiIGZpbGw9IiMwMDAiLz48L3N2Zz4=" autoplay muted playsinline preload="auto" aria-label="Time Farm app preview"></video>
           </div>
             </div>
           </div>
@@ -126,6 +126,32 @@
             </div>
             <div class="how__media how__media--wide">
               <video class="how-video" src="assets/video/ScreenRecording_08-31-2025 iPad.MP4" autoplay muted loop playsinline preload="metadata" aria-label="Farm preview"></video>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <!-- Tracking showcase -->
+      <section class="section features features--modern track">
+        <div class="container">
+          <div class="feature-grid">
+            <div class="f-card span-6">
+              <div class="f-media">
+                <img src="assets/previews/preview-1.png" alt="App interface screenshot" loading="lazy" />
+              </div>
+              <div class="f-body">
+                <h3>Track from anywhere</h3>
+                <p>Start or continue sessions right from your home screen.</p>
+              </div>
+            </div>
+            <div class="f-card span-6">
+              <div class="f-media">
+                <img src="assets/previews/preview-2.png" alt="App progress view screenshot" loading="lazy" />
+              </div>
+              <div class="f-body">
+                <h3>Track your progress</h3>
+                <p>Watch your streaks grow in a friendly calendar view.</p>
+              </div>
             </div>
           </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -37,27 +37,42 @@ const y = document.getElementById('copyrightYear');
 if (y) y.textContent = String(new Date().getFullYear());
 
 // Hero video: play iPhone1 then iPhone2 sequentially
-document.addEventListener('DOMContentLoaded', () => {
-  const heroVideo = /** @type {HTMLVideoElement|null} */(document.querySelector('.hero-video'));
-  if (!heroVideo) return;
+  document.addEventListener('DOMContentLoaded', () => {
+    const heroVideo = /** @type {HTMLVideoElement|null} */(document.querySelector('.hero-video'));
+    if (!heroVideo) return;
 
-  const playlist = [
-    'assets/video/iPhone1.mp4',
-    'assets/video/iPhone2.mp4',
-  ];
-  let current = 0;
+    const placeholder = 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIxMjA2IiBoZWlnaHQ9IjI2MjIiPjxyZWN0IHdpZHRoPSIxMjA2IiBoZWlnaHQ9IjI2MjIiIGZpbGw9IiMwMDAiLz48L3N2Zz4=';
+    heroVideo.poster = placeholder;
 
-  // Ensure desired attributes
-  heroVideo.loop = false;
-  heroVideo.muted = true;
-  heroVideo.playsInline = true;
-  heroVideo.autoplay = true;
+    const playlist = [
+      'assets/video/iPhone1.mp4',
+      'assets/video/iPhone2.mp4',
+    ];
+    let current = 0;
 
-  const playCurrent = () => {
-    heroVideo.src = playlist[current];
-    // Attempt immediate play; ignore promise rejection (autoplay policies already satisfied due to muted)
-    heroVideo.play().catch(() => {});
-  };
+    // Ensure desired attributes
+    heroVideo.loop = false;
+    heroVideo.muted = true;
+    heroVideo.playsInline = true;
+    heroVideo.autoplay = true;
+    heroVideo.preload = 'auto';
+
+    // Preload videos to keep playback seamless when switching
+    const cache = playlist.map((src) => {
+      const v = document.createElement('video');
+      v.src = src;
+      v.preload = 'auto';
+      v.load();
+      return v;
+    });
+
+    const playCurrent = () => {
+      heroVideo.poster = placeholder;
+      heroVideo.src = cache[current].src;
+      heroVideo.load();
+      // Attempt immediate play; ignore promise rejection (autoplay policies already satisfied due to muted)
+      heroVideo.play().catch(() => {});
+    };
 
   heroVideo.addEventListener('ended', () => {
     current = (current + 1) % playlist.length;

--- a/styles.css
+++ b/styles.css
@@ -86,7 +86,21 @@ body {
 .hero__visual { align-self: center; justify-self: end; }
 .hero__visual { position: relative; }
 .hero__visual img,
-.hero__visual video { width: min(420px, 100%); max-height: min(70svh, 640px); height: auto; border-radius: 26px; box-shadow: 0 30px 80px rgba(0,0,0,0.12); animation: levitate 6s ease-in-out infinite; display: block; object-fit: cover; }
+.hero__visual video {
+  width: min(420px, 100%);
+  max-height: min(70svh, 640px);
+  height: auto;
+  border-radius: 26px;
+  box-shadow: 0 30px 80px rgba(0,0,0,0.12);
+  animation: levitate 6s ease-in-out infinite;
+  display: block;
+  object-fit: cover;
+}
+
+.hero__visual video {
+  aspect-ratio: 201 / 437;
+  background-color: #000;
+}
 .hero__visual::after { content: ""; position: absolute; left: 50%; transform: translateX(-50%); bottom: -8px; width: 60%; height: 18px; filter: blur(10px); border-radius: 50%; background: radial-gradient(closest-side, rgba(0,0,0,0.25), transparent); opacity: 0.25; animation: shadowPulse 6s ease-in-out infinite; }
 
 @keyframes levitate {
@@ -125,11 +139,12 @@ body {
 .f-card .f-body p { margin: 0; color: #333; }
 .f-card.span-7 { grid-column: span 7; }
 .f-card.span-5 { grid-column: span 5; }
+.f-card.span-6 { grid-column: span 6; }
 
 @media (max-width: 980px) {
   .feature-grid { grid-template-columns: 1fr; }
   .f-card { grid-template-columns: 1fr; min-height: 0; }
-  .f-card.span-7, .f-card.span-5 { grid-column: auto; }
+  .f-card.span-7, .f-card.span-6, .f-card.span-5 { grid-column: auto; }
 }
 
 /* Download */
@@ -148,6 +163,11 @@ body {
 .footer__links { display: flex; gap: 16px; }
 .footer__links a { color: #e9fff4; text-decoration: none; opacity: 0.9; }
 .footer__links a:hover { opacity: 1; text-decoration: underline; }
+
+@media (max-width: 600px) {
+  .footer__grid { flex-direction: column; align-items: flex-start; }
+  .footer__links { flex-wrap: wrap; }
+}
 
 /* Author section */
 .author { background: linear-gradient(135deg, #fff, var(--mint)); }


### PR DESCRIPTION
## Summary
- add tiny data URI poster to hero video and reset it during clip swaps
- stack footer sections vertically on mobile to avoid crowding
- match poster dimensions to hero video so placeholder keeps correct shape
- showcase tracking features with two new cards using existing preview images
- drop temporary tracking PNG assets in favor of existing images

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b59d765d4c832cabe992597712ceb7