### PR TITLE
fix: stabilize hero video layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,7 +93,7 @@
             <p class="subtle">Now available on iOS. Android in exploration.</p>
           </div>
           <div class="hero__visual">
-            <video class="hero-video" src="assets/video/iPhone1.mp4" poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" autoplay muted playsinline preload="auto" aria-label="Time Farm app preview"></video>
+            <video class="hero-video" src="assets/video/iPhone1.mp4" poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" width="1206" height="2622" autoplay muted playsinline preload="auto" aria-label="Time Farm app preview"></video>
           </div>
             </div>
           </div>

--- a/styles.css
+++ b/styles.css
@@ -88,8 +88,7 @@ body {
 .hero__visual img,
 .hero__visual video {
   width: min(420px, 100%);
-  max-height: min(70svh, 640px);
-  height: auto;
+  height: min(70svh, 640px);
   border-radius: 26px;
   box-shadow: 0 30px 80px rgba(0,0,0,0.12);
   animation: levitate 6s ease-in-out infinite;
@@ -98,7 +97,7 @@ body {
 }
 
 .hero__visual video {
-  aspect-ratio: 9 / 19.5;
+  aspect-ratio: 201 / 437;
   background-color: #000;
 }
 .hero__visual::after { content: ""; position: absolute; left: 50%; transform: translateX(-50%); bottom: -8px; width: 60%; height: 18px; filter: blur(10px); border-radius: 50%; background: radial-gradient(closest-side, rgba(0,0,0,0.25), transparent); opacity: 0.25; animation: shadowPulse 6s ease-in-out infinite; }
@@ -204,12 +203,12 @@ body {
 .story--plain p { margin: 0; font-size: clamp(16px, 2vw, 18px); }
 
 /* Responsive */
-@media (max-width: 980px) {
-  .hero__grid { grid-template-columns: 1fr; }
-  .hero__visual { justify-self: center; }
-  .hero__visual img,
-  .hero__visual video { width: min(82%, 520px); max-height: 58svh; }
-}
+  @media (max-width: 980px) {
+    .hero__grid { grid-template-columns: 1fr; }
+    .hero__visual { justify-self: center; }
+    .hero__visual img,
+    .hero__visual video { width: min(420px, 100%); height: 65svh; }
+  }
 
 @media (max-width: 900px) {
   .feature { grid-template-columns: 1fr; }


### PR DESCRIPTION
## Summary
- align hero video's width, height, and aspect ratio with intrinsic 1206×2622 dimensions to prevent layout shift before playback
- fix placeholder height flicker by locking hero video height with explicit CSS rule
- ensure hero video uses full width on phones and increase mobile height to 65 svh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5e44fd63c832c9b4a3cfe38ed69e6