### PR TITLE
Use consistent SVG icons for onboarding steps

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,75 +4,113 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Time Farm — Cute Pomodoro Timer with Pets</title>
-    <meta name="description" content="Time Farm is a cute Pomodoro-style productivity timer. Finish a focus session, unlock a new pet, and grow your farm while getting things done." />
+    <meta
+      name="description"
+      content="Time Farm is a cute Pomodoro-style productivity timer. Finish a focus session, unlock a new pet, and grow your farm while getting things done."
+    />
     <meta name="robots" content="index,follow" />
     <meta name="theme-color" content="#2bd88f" />
     <meta name="color-scheme" content="light" />
 
     <!-- Open Graph -->
-    <meta property="og:title" content="Time Farm — Cute Pomodoro Timer with Pets" />
-    <meta property="og:description" content="Finish a focus session, unlock a new pet, and grow your farm." />
+    <meta
+      property="og:title"
+      content="Time Farm — Cute Pomodoro Timer with Pets"
+    />
+    <meta
+      property="og:description"
+      content="Finish a focus session, unlock a new pet, and grow your farm."
+    />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://timefarm.productive-lab.com" />
     <meta property="og:site_name" content="Time Farm" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:image" content="assets/og-cover.svg" />
-    <meta property="og:image:alt" content="Time Farm — cute productivity timer with pets and a cozy farm" />
+    <meta
+      property="og:image:alt"
+      content="Time Farm — cute productivity timer with pets and a cozy farm"
+    />
     <link rel="canonical" href="https://timefarm.productive-lab.com" />
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@NikFanton" />
     <meta name="twitter:creator" content="@NikFanton" />
-    <meta name="twitter:title" content="Time Farm — Cute Pomodoro Timer with Pets" />
-    <meta name="twitter:description" content="Finish a focus session, unlock a new pet, and grow your farm." />
+    <meta
+      name="twitter:title"
+      content="Time Farm — Cute Pomodoro Timer with Pets"
+    />
+    <meta
+      name="twitter:description"
+      content="Finish a focus session, unlock a new pet, and grow your farm."
+    />
     <meta name="twitter:image" content="assets/og-cover.svg" />
 
     <meta name="apple-itunes-app" content="app-id=6738962950" />
 
     <link rel="icon" href="assets/favicon.svg" />
     <link rel="apple-touch-icon" href="assets/logo/logo_5_5.jpeg" />
-    <link rel="mask-icon" href="assets/favicon.svg" color="#2bd88f">
+    <link rel="mask-icon" href="assets/favicon.svg" color="#2bd88f" />
     <link rel="manifest" href="site.webmanifest" />
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700;800&family=Inter:wght@400;600;700;800&family=Caveat:wght@600;700&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700;800&family=Inter:wght@400;600;700;800&family=Caveat:wght@600;700&display=swap"
+      rel="stylesheet"
+    />
     <link rel="stylesheet" href="styles.css" />
-    
+
     <!-- Structured Data -->
     <script type="application/ld+json">
-    {
-      "@context": "https://schema.org",
-      "@type": "MobileApplication",
-      "name": "Time Farm",
-      "applicationCategory": "ProductivityApplication",
-      "operatingSystem": "iOS",
-      "description": "Time Farm is a cute Pomodoro-style productivity timer. Finish a focus session, unlock a new pet, and grow your farm while getting things done.",
-      "url": "https://timefarm.productive-lab.com",
-      "inLanguage": "en",
-      "image": "https://timefarm.productive-lab.com/assets/og-cover.svg",
-      "downloadUrl": "https://apps.apple.com/app/id6738962950",
-      "publisher": {
-        "@type": "Person",
-        "name": "Mykyta Huchenko",
-        "sameAs": [
-          "https://x.com/NikFanton",
-          "https://www.instagram.com/guchenych/",
-          "https://www.youtube.com/channel/UCxXWPA1MRXlrBMa3BgYmEqg"
-        ]
+      {
+        "@context": "https://schema.org",
+        "@type": "MobileApplication",
+        "name": "Time Farm",
+        "applicationCategory": "ProductivityApplication",
+        "operatingSystem": "iOS",
+        "description": "Time Farm is a cute Pomodoro-style productivity timer. Finish a focus session, unlock a new pet, and grow your farm while getting things done.",
+        "url": "https://timefarm.productive-lab.com",
+        "inLanguage": "en",
+        "image": "https://timefarm.productive-lab.com/assets/og-cover.svg",
+        "downloadUrl": "https://apps.apple.com/app/id6738962950",
+        "publisher": {
+          "@type": "Person",
+          "name": "Mykyta Huchenko",
+          "sameAs": [
+            "https://x.com/NikFanton",
+            "https://www.instagram.com/guchenych/",
+            "https://www.youtube.com/channel/UCxXWPA1MRXlrBMa3BgYmEqg"
+          ]
+        }
       }
-    }
     </script>
   </head>
   <body>
     <header class="site-header">
       <nav class="nav">
         <a class="brand" href="#top" aria-label="Time Farm home">
-          <img src="assets/logo/logo_5_dark_transparant.png" alt="Time Farm logo" height="28" style="display:inline-block"/>
+          <img
+            src="assets/logo/logo_5_dark_transparant.png"
+            alt="Time Farm logo"
+            height="28"
+            style="display: inline-block"
+          />
           <span>Time Farm</span>
         </a>
         <div class="nav-cta">
-          <a class="btn btn--ghost" href="https://productive-lab.com/time-farm/support" target="_blank" rel="noopener">Support</a>
-          <a class="btn btn--ghost" href="https://productive-lab.com" target="_blank" rel="noopener">Other apps</a>
+          <a
+            class="btn btn--ghost"
+            href="https://productive-lab.com/time-farm/support"
+            target="_blank"
+            rel="noopener"
+            >Support</a
+          >
+          <a
+            class="btn btn--ghost"
+            href="https://productive-lab.com"
+            target="_blank"
+            rel="noopener"
+            >Other apps</a
+          >
           <a class="btn btn--dark" href="#download">Get the App</a>
         </div>
       </nav>
@@ -84,17 +122,40 @@
         <div class="container">
           <div class="hero__card">
             <div class="hero__grid">
-          <div class="hero__copy">
-            <h1>Get things done in a fun way</h1>
-            <p>Finish a focus session, unlock a new pet, and grow your cozy farm. Time Farm makes productivity cute and rewarding.</p>
-            <div class="cta-row">
-              <a class="badge" href="https://apps.apple.com/app/id6738962950" target="_blank" rel="noopener" aria-label="Download on the App Store"> Download on the App Store</a>
-            </div>
-            <p class="subtle">Now available on iOS. Android in exploration.</p>
-          </div>
-          <div class="hero__visual">
-            <video class="hero-video" src="assets/video/iPhone1.mp4" poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" width="1206" height="2622" autoplay muted playsinline preload="auto" aria-label="Time Farm app preview"></video>
-          </div>
+              <div class="hero__copy">
+                <h1>Get things done in a fun way</h1>
+                <p>
+                  Finish a focus session, unlock a new pet, and grow your cozy
+                  farm. Time Farm makes productivity cute and rewarding.
+                </p>
+                <div class="cta-row">
+                  <a
+                    class="badge"
+                    href="https://apps.apple.com/app/id6738962950"
+                    target="_blank"
+                    rel="noopener"
+                    aria-label="Download on the App Store"
+                    > Download on the App Store</a
+                  >
+                </div>
+                <p class="subtle">
+                  Now available on iOS. Android in exploration.
+                </p>
+              </div>
+              <div class="hero__visual">
+                <video
+                  class="hero-video"
+                  src="assets/video/iPhone1.mp4"
+                  poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
+                  width="1206"
+                  height="2622"
+                  autoplay
+                  muted
+                  playsinline
+                  preload="auto"
+                  aria-label="Time Farm app preview"
+                ></video>
+              </div>
             </div>
           </div>
         </div>
@@ -104,7 +165,10 @@
       <section id="story" class="section story story--plain">
         <div class="container story__plain">
           <h2>Struggle to focus? It doesn’t have to be.</h2>
-          <p>Distractions are everywhere — but with a friendly companion and simple structure, staying on track feels easier and more fun.</p>
+          <p>
+            Distractions are everywhere — but with a friendly companion and
+            simple structure, staying on track feels easier and more fun.
+          </p>
         </div>
       </section>
 
@@ -115,17 +179,82 @@
             <h2 class="section-title section-title--center">How it works</h2>
             <div class="how__grid">
               <ul class="steps" aria-label="Steps to use Time Farm">
-                <li><span class="icon paw" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="4" r="2" /><circle cx="18" cy="8" r="2" /><circle cx="20" cy="16" r="2" /><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z" /></svg></span><span>Pick an animal to focus with you.</span></li>
-                <li><span class="icon timer" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="10" x2="14" y1="2" y2="2" /><line x1="12" x2="15" y1="14" y2="11" /><circle cx="12" cy="14" r="8" /></svg></span><span>Choose how long you want to focus.</span></li>
-                <li><span class="icon check" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg></span><span>Focus on your tasks!</span></li>
+                <li>
+                  <span class="icon paw" aria-hidden="true"
+                    ><svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <circle cx="6" cy="9" r="2" />
+                      <circle cx="9" cy="5" r="2" />
+                      <circle cx="15" cy="5" r="2" />
+                      <circle cx="18" cy="9" r="2" />
+                      <circle cx="12" cy="17" r="5" /></svg></span
+                  ><span>Pick an animal to focus with you.</span>
+                </li>
+                <li>
+                  <span class="icon timer" aria-hidden="true"
+                    ><svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <line x1="10" x2="14" y1="2" y2="2" />
+                      <line x1="12" x2="15" y1="14" y2="11" />
+                      <circle cx="12" cy="14" r="8" /></svg></span
+                  ><span>Choose how long you want to focus.</span>
+                </li>
+                <li>
+                  <span class="icon check" aria-hidden="true"
+                    ><svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      stroke-width="2"
+                      stroke-linecap="round"
+                      stroke-linejoin="round"
+                    >
+                      <path d="M20 6 9 17l-5-5" /></svg></span
+                  ><span>Focus on your tasks!</span>
+                </li>
               </ul>
-              <img class="how__shot" src="assets/onboarding/timer.png" alt="Timer and pet picker" loading="lazy" />
+              <img
+                class="how__shot"
+                src="assets/onboarding/timer.png"
+                alt="Timer and pet picker"
+                loading="lazy"
+              />
             </div>
             <div class="how__farmIntro">
               <h3>With each focus session, your farm grows</h3>
             </div>
             <div class="how__media how__media--wide">
-              <video class="how-video" src="assets/video/ScreenRecording_08-31-2025 iPad.MP4" autoplay muted loop playsinline preload="metadata" aria-label="Farm preview"></video>
+              <video
+                class="how-video"
+                src="assets/video/ScreenRecording_08-31-2025 iPad.MP4"
+                autoplay
+                muted
+                loop
+                playsinline
+                preload="metadata"
+                aria-label="Farm preview"
+              ></video>
             </div>
           </div>
 
@@ -134,9 +263,17 @@
               <div class="how__grid">
                 <div class="how__content">
                   <h3>Live Activity support</h3>
-                  <p>Keep the timer visible right in your Live Activity while you focus.</p>
+                  <p>
+                    Keep the timer visible right in your Live Activity while you
+                    focus.
+                  </p>
                 </div>
-                <img class="how__shot" src="assets/onboarding/slice1.png" alt="Live Activity timer" loading="lazy" />
+                <img
+                  class="how__shot"
+                  src="assets/onboarding/slice1.png"
+                  alt="Live Activity timer"
+                  loading="lazy"
+                />
               </div>
             </div>
 
@@ -144,9 +281,16 @@
               <div class="how__grid">
                 <div class="how__content">
                   <h3>Track your progress</h3>
-                  <p>See completed sessions and watch your productivity grow.</p>
+                  <p>
+                    See completed sessions and watch your productivity grow.
+                  </p>
                 </div>
-                <img class="how__shot" src="assets/onboarding/slice2.png" alt="Progress tracking screen" loading="lazy" />
+                <img
+                  class="how__shot"
+                  src="assets/onboarding/slice2.png"
+                  alt="Progress tracking screen"
+                  loading="lazy"
+                />
               </div>
             </div>
           </div>
@@ -158,11 +302,18 @@
         <div class="container">
           <div class="science__card">
             <div class="science__media" aria-hidden="true">
-              <img src="assets/onboarding/cat-scientist-2.png" alt="" loading="lazy" />
+              <img
+                src="assets/onboarding/cat-scientist-2.png"
+                alt=""
+                loading="lazy"
+              />
             </div>
             <div class="science__content">
               <h2>Backed by science</h2>
-              <p>Built on proven focus methods to help you work with your brain, not against it.</p>
+              <p>
+                Built on proven focus methods to help you work with your brain,
+                not against it.
+              </p>
             </div>
           </div>
         </div>
@@ -175,7 +326,14 @@
             <h2>Download Time Farm</h2>
             <p>Available on the App Store.</p>
             <div class="store-badges">
-              <a class="badge" href="https://apps.apple.com/app/id6738962950" target="_blank" rel="noopener" aria-label="Download on the App Store"> Download on the App Store</a>
+              <a
+                class="badge"
+                href="https://apps.apple.com/app/id6738962950"
+                target="_blank"
+                rel="noopener"
+                aria-label="Download on the App Store"
+                > Download on the App Store</a
+              >
             </div>
           </div>
         </div>
@@ -186,10 +344,25 @@
         <div class="container author__grid">
           <div class="author__text">
             <h2>Made by Mykyta Huchenko</h2>
-            <p>I'm a solo app developer building apps that make life more fun and productive. Time Farm is my cozy take on staying focused.</p>
+            <p>
+              I'm a solo app developer building apps that make life more fun and
+              productive. Time Farm is my cozy take on staying focused.
+            </p>
             <div class="socials">
-              <a href="https://x.com/NikFanton" target="_blank" rel="noopener" aria-label="Follow on X">X / @NikFanton</a>
-              <a href="https://www.instagram.com/guchenych/" target="_blank" rel="noopener" aria-label="Follow on Instagram">Instagram / @guchenych</a>
+              <a
+                href="https://x.com/NikFanton"
+                target="_blank"
+                rel="noopener"
+                aria-label="Follow on X"
+                >X / @NikFanton</a
+              >
+              <a
+                href="https://www.instagram.com/guchenych/"
+                target="_blank"
+                rel="noopener"
+                aria-label="Follow on Instagram"
+                >Instagram / @guchenych</a
+              >
             </div>
           </div>
           <div class="author__sig" aria-label="Signature of Mykyta Huchenko">
@@ -206,7 +379,9 @@
         <div>
           <strong>Time Farm</strong>
           <div class="subtle">Made with care for productive days.</div>
-          <div class="subtle">© <span id="copyrightYear"></span> Mykyta Huchenko</div>
+          <div class="subtle">
+            © <span id="copyrightYear"></span> Mykyta Huchenko
+          </div>
         </div>
         <div class="footer__links">
           <a href="#top">Home</a>
@@ -214,14 +389,29 @@
           <a href="#how">How</a>
           <a href="#science">Science</a>
           <a href="#download">Get the App</a>
-          <a href="https://productive-lab.com/time-farm/support" target="_blank" rel="noopener">Support</a>
+          <a
+            href="https://productive-lab.com/time-farm/support"
+            target="_blank"
+            rel="noopener"
+            >Support</a
+          >
           <a href="https://x.com/NikFanton" target="_blank" rel="noopener">X</a>
-          <a href="https://www.youtube.com/channel/UCxXWPA1MRXlrBMa3BgYmEqg" target="_blank" rel="noopener">YouTube</a>
-          <a href="https://www.instagram.com/guchenych/" target="_blank" rel="noopener">Instagram</a>
+          <a
+            href="https://www.youtube.com/channel/UCxXWPA1MRXlrBMa3BgYmEqg"
+            target="_blank"
+            rel="noopener"
+            >YouTube</a
+          >
+          <a
+            href="https://www.instagram.com/guchenych/"
+            target="_blank"
+            rel="noopener"
+            >Instagram</a
+          >
         </div>
       </div>
     </footer>
 
     <script src="script.js"></script>
   </body>
-  </html>
+</html>

--- a/index.html
+++ b/index.html
@@ -4,113 +4,75 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Time Farm — Cute Pomodoro Timer with Pets</title>
-    <meta
-      name="description"
-      content="Time Farm is a cute Pomodoro-style productivity timer. Finish a focus session, unlock a new pet, and grow your farm while getting things done."
-    />
+    <meta name="description" content="Time Farm is a cute Pomodoro-style productivity timer. Finish a focus session, unlock a new pet, and grow your farm while getting things done." />
     <meta name="robots" content="index,follow" />
     <meta name="theme-color" content="#2bd88f" />
     <meta name="color-scheme" content="light" />
 
     <!-- Open Graph -->
-    <meta
-      property="og:title"
-      content="Time Farm — Cute Pomodoro Timer with Pets"
-    />
-    <meta
-      property="og:description"
-      content="Finish a focus session, unlock a new pet, and grow your farm."
-    />
+    <meta property="og:title" content="Time Farm — Cute Pomodoro Timer with Pets" />
+    <meta property="og:description" content="Finish a focus session, unlock a new pet, and grow your farm." />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://timefarm.productive-lab.com" />
     <meta property="og:site_name" content="Time Farm" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:image" content="assets/og-cover.svg" />
-    <meta
-      property="og:image:alt"
-      content="Time Farm — cute productivity timer with pets and a cozy farm"
-    />
+    <meta property="og:image:alt" content="Time Farm — cute productivity timer with pets and a cozy farm" />
     <link rel="canonical" href="https://timefarm.productive-lab.com" />
     <!-- Twitter -->
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@NikFanton" />
     <meta name="twitter:creator" content="@NikFanton" />
-    <meta
-      name="twitter:title"
-      content="Time Farm — Cute Pomodoro Timer with Pets"
-    />
-    <meta
-      name="twitter:description"
-      content="Finish a focus session, unlock a new pet, and grow your farm."
-    />
+    <meta name="twitter:title" content="Time Farm — Cute Pomodoro Timer with Pets" />
+    <meta name="twitter:description" content="Finish a focus session, unlock a new pet, and grow your farm." />
     <meta name="twitter:image" content="assets/og-cover.svg" />
 
     <meta name="apple-itunes-app" content="app-id=6738962950" />
 
     <link rel="icon" href="assets/favicon.svg" />
     <link rel="apple-touch-icon" href="assets/logo/logo_5_5.jpeg" />
-    <link rel="mask-icon" href="assets/favicon.svg" color="#2bd88f" />
+    <link rel="mask-icon" href="assets/favicon.svg" color="#2bd88f">
     <link rel="manifest" href="site.webmanifest" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700;800&family=Inter:wght@400;600;700;800&family=Caveat:wght@600;700&display=swap"
-      rel="stylesheet"
-    />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;600;700;800&family=Inter:wght@400;600;700;800&family=Caveat:wght@600;700&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="styles.css" />
-
+    
     <!-- Structured Data -->
     <script type="application/ld+json">
-      {
-        "@context": "https://schema.org",
-        "@type": "MobileApplication",
-        "name": "Time Farm",
-        "applicationCategory": "ProductivityApplication",
-        "operatingSystem": "iOS",
-        "description": "Time Farm is a cute Pomodoro-style productivity timer. Finish a focus session, unlock a new pet, and grow your farm while getting things done.",
-        "url": "https://timefarm.productive-lab.com",
-        "inLanguage": "en",
-        "image": "https://timefarm.productive-lab.com/assets/og-cover.svg",
-        "downloadUrl": "https://apps.apple.com/app/id6738962950",
-        "publisher": {
-          "@type": "Person",
-          "name": "Mykyta Huchenko",
-          "sameAs": [
-            "https://x.com/NikFanton",
-            "https://www.instagram.com/guchenych/",
-            "https://www.youtube.com/channel/UCxXWPA1MRXlrBMa3BgYmEqg"
-          ]
-        }
+    {
+      "@context": "https://schema.org",
+      "@type": "MobileApplication",
+      "name": "Time Farm",
+      "applicationCategory": "ProductivityApplication",
+      "operatingSystem": "iOS",
+      "description": "Time Farm is a cute Pomodoro-style productivity timer. Finish a focus session, unlock a new pet, and grow your farm while getting things done.",
+      "url": "https://timefarm.productive-lab.com",
+      "inLanguage": "en",
+      "image": "https://timefarm.productive-lab.com/assets/og-cover.svg",
+      "downloadUrl": "https://apps.apple.com/app/id6738962950",
+      "publisher": {
+        "@type": "Person",
+        "name": "Mykyta Huchenko",
+        "sameAs": [
+          "https://x.com/NikFanton",
+          "https://www.instagram.com/guchenych/",
+          "https://www.youtube.com/channel/UCxXWPA1MRXlrBMa3BgYmEqg"
+        ]
       }
+    }
     </script>
   </head>
   <body>
     <header class="site-header">
       <nav class="nav">
         <a class="brand" href="#top" aria-label="Time Farm home">
-          <img
-            src="assets/logo/logo_5_dark_transparant.png"
-            alt="Time Farm logo"
-            height="28"
-            style="display: inline-block"
-          />
+          <img src="assets/logo/logo_5_dark_transparant.png" alt="Time Farm logo" height="28" style="display:inline-block"/>
           <span>Time Farm</span>
         </a>
         <div class="nav-cta">
-          <a
-            class="btn btn--ghost"
-            href="https://productive-lab.com/time-farm/support"
-            target="_blank"
-            rel="noopener"
-            >Support</a
-          >
-          <a
-            class="btn btn--ghost"
-            href="https://productive-lab.com"
-            target="_blank"
-            rel="noopener"
-            >Other apps</a
-          >
+          <a class="btn btn--ghost" href="https://productive-lab.com/time-farm/support" target="_blank" rel="noopener">Support</a>
+          <a class="btn btn--ghost" href="https://productive-lab.com" target="_blank" rel="noopener">Other apps</a>
           <a class="btn btn--dark" href="#download">Get the App</a>
         </div>
       </nav>
@@ -122,40 +84,17 @@
         <div class="container">
           <div class="hero__card">
             <div class="hero__grid">
-              <div class="hero__copy">
-                <h1>Get things done in a fun way</h1>
-                <p>
-                  Finish a focus session, unlock a new pet, and grow your cozy
-                  farm. Time Farm makes productivity cute and rewarding.
-                </p>
-                <div class="cta-row">
-                  <a
-                    class="badge"
-                    href="https://apps.apple.com/app/id6738962950"
-                    target="_blank"
-                    rel="noopener"
-                    aria-label="Download on the App Store"
-                    > Download on the App Store</a
-                  >
-                </div>
-                <p class="subtle">
-                  Now available on iOS. Android in exploration.
-                </p>
-              </div>
-              <div class="hero__visual">
-                <video
-                  class="hero-video"
-                  src="assets/video/iPhone1.mp4"
-                  poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw=="
-                  width="1206"
-                  height="2622"
-                  autoplay
-                  muted
-                  playsinline
-                  preload="auto"
-                  aria-label="Time Farm app preview"
-                ></video>
-              </div>
+          <div class="hero__copy">
+            <h1>Get things done in a fun way</h1>
+            <p>Finish a focus session, unlock a new pet, and grow your cozy farm. Time Farm makes productivity cute and rewarding.</p>
+            <div class="cta-row">
+              <a class="badge" href="https://apps.apple.com/app/id6738962950" target="_blank" rel="noopener" aria-label="Download on the App Store"> Download on the App Store</a>
+            </div>
+            <p class="subtle">Now available on iOS. Android in exploration.</p>
+          </div>
+          <div class="hero__visual">
+            <video class="hero-video" src="assets/video/iPhone1.mp4" poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==" width="1206" height="2622" autoplay muted playsinline preload="auto" aria-label="Time Farm app preview"></video>
+          </div>
             </div>
           </div>
         </div>
@@ -165,10 +104,7 @@
       <section id="story" class="section story story--plain">
         <div class="container story__plain">
           <h2>Struggle to focus? It doesn’t have to be.</h2>
-          <p>
-            Distractions are everywhere — but with a friendly companion and
-            simple structure, staying on track feels easier and more fun.
-          </p>
+          <p>Distractions are everywhere — but with a friendly companion and simple structure, staying on track feels easier and more fun.</p>
         </div>
       </section>
 
@@ -179,82 +115,17 @@
             <h2 class="section-title section-title--center">How it works</h2>
             <div class="how__grid">
               <ul class="steps" aria-label="Steps to use Time Farm">
-                <li>
-                  <span class="icon paw" aria-hidden="true"
-                    ><svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="24"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    >
-                      <circle cx="6" cy="9" r="2" />
-                      <circle cx="9" cy="5" r="2" />
-                      <circle cx="15" cy="5" r="2" />
-                      <circle cx="18" cy="9" r="2" />
-                      <circle cx="12" cy="17" r="5" /></svg></span
-                  ><span>Pick an animal to focus with you.</span>
-                </li>
-                <li>
-                  <span class="icon timer" aria-hidden="true"
-                    ><svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="24"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    >
-                      <line x1="10" x2="14" y1="2" y2="2" />
-                      <line x1="12" x2="15" y1="14" y2="11" />
-                      <circle cx="12" cy="14" r="8" /></svg></span
-                  ><span>Choose how long you want to focus.</span>
-                </li>
-                <li>
-                  <span class="icon check" aria-hidden="true"
-                    ><svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="24"
-                      height="24"
-                      viewBox="0 0 24 24"
-                      fill="none"
-                      stroke="currentColor"
-                      stroke-width="2"
-                      stroke-linecap="round"
-                      stroke-linejoin="round"
-                    >
-                      <path d="M20 6 9 17l-5-5" /></svg></span
-                  ><span>Focus on your tasks!</span>
-                </li>
+                <li><span class="icon paw" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="4" r="2" /><circle cx="18" cy="8" r="2" /><circle cx="20" cy="16" r="2" /><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z" /></svg></span><span>Pick an animal to focus with you.</span></li>
+                <li><span class="icon timer" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="10" x2="14" y1="2" y2="2" /><line x1="12" x2="15" y1="14" y2="11" /><circle cx="12" cy="14" r="8" /></svg></span><span>Choose how long you want to focus.</span></li>
+                <li><span class="icon check" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg></span><span>Focus on your tasks!</span></li>
               </ul>
-              <img
-                class="how__shot"
-                src="assets/onboarding/timer.png"
-                alt="Timer and pet picker"
-                loading="lazy"
-              />
+              <img class="how__shot" src="assets/onboarding/timer.png" alt="Timer and pet picker" loading="lazy" />
             </div>
             <div class="how__farmIntro">
               <h3>With each focus session, your farm grows</h3>
             </div>
             <div class="how__media how__media--wide">
-              <video
-                class="how-video"
-                src="assets/video/ScreenRecording_08-31-2025 iPad.MP4"
-                autoplay
-                muted
-                loop
-                playsinline
-                preload="metadata"
-                aria-label="Farm preview"
-              ></video>
+              <video class="how-video" src="assets/video/ScreenRecording_08-31-2025 iPad.MP4" autoplay muted loop playsinline preload="metadata" aria-label="Farm preview"></video>
             </div>
           </div>
 
@@ -263,17 +134,9 @@
               <div class="how__grid">
                 <div class="how__content">
                   <h3>Live Activity support</h3>
-                  <p>
-                    Keep the timer visible right in your Live Activity while you
-                    focus.
-                  </p>
+                  <p>Keep the timer visible right in your Live Activity while you focus.</p>
                 </div>
-                <img
-                  class="how__shot"
-                  src="assets/onboarding/slice1.png"
-                  alt="Live Activity timer"
-                  loading="lazy"
-                />
+                <img class="how__shot" src="assets/onboarding/slice1.png" alt="Live Activity timer" loading="lazy" />
               </div>
             </div>
 
@@ -281,16 +144,9 @@
               <div class="how__grid">
                 <div class="how__content">
                   <h3>Track your progress</h3>
-                  <p>
-                    See completed sessions and watch your productivity grow.
-                  </p>
+                  <p>See completed sessions and watch your productivity grow.</p>
                 </div>
-                <img
-                  class="how__shot"
-                  src="assets/onboarding/slice2.png"
-                  alt="Progress tracking screen"
-                  loading="lazy"
-                />
+                <img class="how__shot" src="assets/onboarding/slice2.png" alt="Progress tracking screen" loading="lazy" />
               </div>
             </div>
           </div>
@@ -302,18 +158,11 @@
         <div class="container">
           <div class="science__card">
             <div class="science__media" aria-hidden="true">
-              <img
-                src="assets/onboarding/cat-scientist-2.png"
-                alt=""
-                loading="lazy"
-              />
+              <img src="assets/onboarding/cat-scientist-2.png" alt="" loading="lazy" />
             </div>
             <div class="science__content">
               <h2>Backed by science</h2>
-              <p>
-                Built on proven focus methods to help you work with your brain,
-                not against it.
-              </p>
+              <p>Built on proven focus methods to help you work with your brain, not against it.</p>
             </div>
           </div>
         </div>
@@ -326,14 +175,7 @@
             <h2>Download Time Farm</h2>
             <p>Available on the App Store.</p>
             <div class="store-badges">
-              <a
-                class="badge"
-                href="https://apps.apple.com/app/id6738962950"
-                target="_blank"
-                rel="noopener"
-                aria-label="Download on the App Store"
-                > Download on the App Store</a
-              >
+              <a class="badge" href="https://apps.apple.com/app/id6738962950" target="_blank" rel="noopener" aria-label="Download on the App Store"> Download on the App Store</a>
             </div>
           </div>
         </div>
@@ -344,25 +186,10 @@
         <div class="container author__grid">
           <div class="author__text">
             <h2>Made by Mykyta Huchenko</h2>
-            <p>
-              I'm a solo app developer building apps that make life more fun and
-              productive. Time Farm is my cozy take on staying focused.
-            </p>
+            <p>I'm a solo app developer building apps that make life more fun and productive. Time Farm is my cozy take on staying focused.</p>
             <div class="socials">
-              <a
-                href="https://x.com/NikFanton"
-                target="_blank"
-                rel="noopener"
-                aria-label="Follow on X"
-                >X / @NikFanton</a
-              >
-              <a
-                href="https://www.instagram.com/guchenych/"
-                target="_blank"
-                rel="noopener"
-                aria-label="Follow on Instagram"
-                >Instagram / @guchenych</a
-              >
+              <a href="https://x.com/NikFanton" target="_blank" rel="noopener" aria-label="Follow on X">X / @NikFanton</a>
+              <a href="https://www.instagram.com/guchenych/" target="_blank" rel="noopener" aria-label="Follow on Instagram">Instagram / @guchenych</a>
             </div>
           </div>
           <div class="author__sig" aria-label="Signature of Mykyta Huchenko">
@@ -379,9 +206,7 @@
         <div>
           <strong>Time Farm</strong>
           <div class="subtle">Made with care for productive days.</div>
-          <div class="subtle">
-            © <span id="copyrightYear"></span> Mykyta Huchenko
-          </div>
+          <div class="subtle">© <span id="copyrightYear"></span> Mykyta Huchenko</div>
         </div>
         <div class="footer__links">
           <a href="#top">Home</a>
@@ -389,29 +214,14 @@
           <a href="#how">How</a>
           <a href="#science">Science</a>
           <a href="#download">Get the App</a>
-          <a
-            href="https://productive-lab.com/time-farm/support"
-            target="_blank"
-            rel="noopener"
-            >Support</a
-          >
+          <a href="https://productive-lab.com/time-farm/support" target="_blank" rel="noopener">Support</a>
           <a href="https://x.com/NikFanton" target="_blank" rel="noopener">X</a>
-          <a
-            href="https://www.youtube.com/channel/UCxXWPA1MRXlrBMa3BgYmEqg"
-            target="_blank"
-            rel="noopener"
-            >YouTube</a
-          >
-          <a
-            href="https://www.instagram.com/guchenych/"
-            target="_blank"
-            rel="noopener"
-            >Instagram</a
-          >
+          <a href="https://www.youtube.com/channel/UCxXWPA1MRXlrBMa3BgYmEqg" target="_blank" rel="noopener">YouTube</a>
+          <a href="https://www.instagram.com/guchenych/" target="_blank" rel="noopener">Instagram</a>
         </div>
       </div>
     </footer>
 
     <script src="script.js"></script>
   </body>
-</html>
+  </html>

--- a/index.html
+++ b/index.html
@@ -115,9 +115,9 @@
             <h2 class="section-title section-title--center">How it works</h2>
             <div class="how__grid">
               <ul class="steps" aria-label="Steps to use Time Farm">
-                <li><span class="icon paw" aria-hidden="true">🐾</span><span>Pick an animal to focus with you.</span></li>
-                <li><span class="icon timer" aria-hidden="true">⏱</span><span>Choose how long you want to focus.</span></li>
-                <li><span class="icon check" aria-hidden="true">✓</span><span>Focus on your tasks!</span></li>
+                <li><span class="icon paw" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="4" r="2" /><circle cx="18" cy="8" r="2" /><circle cx="20" cy="16" r="2" /><path d="M9 10a5 5 0 0 1 5 5v3.5a3.5 3.5 0 0 1-6.84 1.045Q6.52 17.48 4.46 16.84A3.5 3.5 0 0 1 5.5 10Z" /></svg></span><span>Pick an animal to focus with you.</span></li>
+                <li><span class="icon timer" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="10" x2="14" y1="2" y2="2" /><line x1="12" x2="15" y1="14" y2="11" /><circle cx="12" cy="14" r="8" /></svg></span><span>Choose how long you want to focus.</span></li>
+                <li><span class="icon check" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 6 9 17l-5-5" /></svg></span><span>Focus on your tasks!</span></li>
               </ul>
               <img class="how__shot" src="assets/onboarding/timer.png" alt="Timer and pet picker" loading="lazy" />
             </div>

--- a/styles.css
+++ b/styles.css
@@ -17,16 +17,33 @@
   --card: #ffffff;
 }
 
-* { box-sizing: border-box; }
-html, body { height: 100%; overflow-x: hidden; }
-html { background: #f7faf8; }
+* {
+  box-sizing: border-box;
+}
+html,
+body {
+  height: 100%;
+  overflow-x: hidden;
+}
+html {
+  background: #f7faf8;
+}
 body {
   margin: 0;
-  font-family: 'Plus Jakarta Sans', 'Inter', system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  font-family:
+    "Plus Jakarta Sans",
+    "Inter",
+    system-ui,
+    -apple-system,
+    Segoe UI,
+    Roboto,
+    Helvetica,
+    Arial,
+    sans-serif;
   color: var(--text);
-  background: radial-gradient(1400px 600px at 10% -10%, var(--rose), transparent),
-              radial-gradient(1000px 600px at 110% 10%, var(--sky), transparent),
-              #f7faf8;
+  background:
+    radial-gradient(1400px 600px at 10% -10%, var(--rose), transparent),
+    radial-gradient(1000px 600px at 110% 10%, var(--sky), transparent), #f7faf8;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }
@@ -38,59 +55,185 @@ body {
 }
 
 /* Header */
-.site-header { position: sticky; top: 0; z-index: 20; backdrop-filter: saturate(180%) blur(10px); }
-.nav {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: 14px 20px; background: rgba(255,255,255,0.7); border-bottom: 1px solid rgba(0,0,0,0.05);
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: saturate(180%) blur(10px);
 }
-.brand { display: inline-flex; gap: 12px; align-items: center; text-decoration: none; color: inherit; font-weight: 800; font-size: clamp(20px, 2.2vw, 26px); }
-.brand-mark { font-size: 20px; }
-.brand img { height: clamp(32px, 3.2vw, 40px); width: auto; }
-.nav-cta { display: flex; gap: 10px; }
-.nav-link { color: inherit; text-decoration: none; font-weight: 600; padding: 8px 10px; opacity: 0.9; }
-.nav-link:hover { opacity: 1; text-decoration: underline; }
+.nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 20px;
+  background: rgba(255, 255, 255, 0.7);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+}
+.brand {
+  display: inline-flex;
+  gap: 12px;
+  align-items: center;
+  text-decoration: none;
+  color: inherit;
+  font-weight: 800;
+  font-size: clamp(20px, 2.2vw, 26px);
+}
+.brand-mark {
+  font-size: 20px;
+}
+.brand img {
+  height: clamp(32px, 3.2vw, 40px);
+  width: auto;
+}
+.nav-cta {
+  display: flex;
+  gap: 10px;
+}
+.nav-link {
+  color: inherit;
+  text-decoration: none;
+  font-weight: 600;
+  padding: 8px 10px;
+  opacity: 0.9;
+}
+.nav-link:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
 
 /* Buttons */
 .btn {
   --bg: var(--brand);
   --ink: var(--brand-ink);
-  display: inline-flex; align-items: center; justify-content: center;
-  background: var(--bg); color: #052a1f; text-decoration: none; border: none; cursor: pointer;
-  padding: 10px 14px; border-radius: 12px; font-weight: 700; box-shadow: 0 2px 0 rgba(0,0,0,0.1);
-  transition: transform 0.08s ease, box-shadow 0.08s ease, background 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  color: #052a1f;
+  text-decoration: none;
+  border: none;
+  cursor: pointer;
+  padding: 10px 14px;
+  border-radius: 12px;
+  font-weight: 700;
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.1);
+  transition:
+    transform 0.08s ease,
+    box-shadow 0.08s ease,
+    background 0.2s ease;
 }
-.btn:hover { transform: translateY(-1px); box-shadow: 0 6px 16px rgba(43,216,143,0.3); }
-.btn:active { transform: translateY(0); box-shadow: 0 2px 0 rgba(0,0,0,0.08); }
-.btn--ghost { background: transparent; border: 1px solid rgba(0,0,0,0.12); color: inherit; box-shadow: none; }
-.btn--lg { padding: 14px 18px; font-size: 16px; }
-.btn--dark { background: #111; color: #fff; }
-.btn--dark:hover { box-shadow: 0 8px 20px rgba(0,0,0,0.25); }
+.btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 16px rgba(43, 216, 143, 0.3);
+}
+.btn:active {
+  transform: translateY(0);
+  box-shadow: 0 2px 0 rgba(0, 0, 0, 0.08);
+}
+.btn--ghost {
+  background: transparent;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  color: inherit;
+  box-shadow: none;
+}
+.btn--lg {
+  padding: 14px 18px;
+  font-size: 16px;
+}
+.btn--dark {
+  background: #111;
+  color: #fff;
+}
+.btn--dark:hover {
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.25);
+}
 
-.subtle { color: var(--muted); font-size: 14px; }
-.visually-hidden { position: absolute !important; clip: rect(1px,1px,1px,1px); padding:0; border:0; height:1px; width:1px; overflow:hidden; }
+.subtle {
+  color: var(--muted);
+  font-size: 14px;
+}
+.visually-hidden {
+  position: absolute !important;
+  clip: rect(1px, 1px, 1px, 1px);
+  padding: 0;
+  border: 0;
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+}
 
 /* Sections */
-.section { padding: 68px 0; }
-.hero { background: linear-gradient(135deg, var(--rose), var(--sky) 60%, var(--butter)); padding: clamp(20px, 3vw, 36px) 0 40px; }
-.features { background: #ffffff; }
-.download { background: linear-gradient(135deg, var(--blue), var(--purple)); }
-.faq { background: #fff; }
-.site-footer { background: #0f1a14; color: #e9fff4; padding: 40px 0; }
+.section {
+  padding: 68px 0;
+}
+.hero {
+  background: linear-gradient(
+    135deg,
+    var(--rose),
+    var(--sky) 60%,
+    var(--butter)
+  );
+  padding: clamp(20px, 3vw, 36px) 0 40px;
+}
+.features {
+  background: #ffffff;
+}
+.download {
+  background: linear-gradient(135deg, var(--blue), var(--purple));
+}
+.faq {
+  background: #fff;
+}
+.site-footer {
+  background: #0f1a14;
+  color: #e9fff4;
+  padding: 40px 0;
+}
 
 /* Hero */
-.hero__grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 32px; align-items: center; }
-.hero h1 { font-size: clamp(36px, 6.5vw, 68px); line-height: 1.02; margin: 0 0 12px; letter-spacing: -0.02em; font-weight: 800; }
-.hero p { font-size: 18px; margin: 0 0 20px; }
-.cta-row { display: flex; gap: 12px; align-items: center; margin: 10px 0 8px; }
-.hero__card { background: rgba(255,255,255,0.7); border: 1px solid rgba(0,0,0,0.06); border-radius: 28px; padding: clamp(20px, 3vw, 32px); box-shadow: 0 30px 80px rgba(0,0,0,0.08); }
-.hero__visual { align-self: center; justify-self: end; }
-.hero__visual { position: relative; }
+.hero__grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 32px;
+  align-items: center;
+}
+.hero h1 {
+  font-size: clamp(36px, 6.5vw, 68px);
+  line-height: 1.02;
+  margin: 0 0 12px;
+  letter-spacing: -0.02em;
+  font-weight: 800;
+}
+.hero p {
+  font-size: 18px;
+  margin: 0 0 20px;
+}
+.cta-row {
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin: 10px 0 8px;
+}
+.hero__card {
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 28px;
+  padding: clamp(20px, 3vw, 32px);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.08);
+}
+.hero__visual {
+  align-self: center;
+  justify-self: end;
+}
+.hero__visual {
+  position: relative;
+}
 .hero__visual img,
 .hero__visual video {
   width: min(420px, 100%);
   height: min(70svh, 640px);
   border-radius: 26px;
-  box-shadow: 0 30px 80px rgba(0,0,0,0.12);
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.12);
   animation: levitate 6s ease-in-out infinite;
   display: block;
   object-fit: cover;
@@ -100,183 +243,625 @@ body {
   aspect-ratio: 201 / 437;
   background-color: #000;
 }
-.hero__visual::after { content: ""; position: absolute; left: 50%; transform: translateX(-50%); bottom: -8px; width: 60%; height: 18px; filter: blur(10px); border-radius: 50%; background: radial-gradient(closest-side, rgba(0,0,0,0.25), transparent); opacity: 0.25; animation: shadowPulse 6s ease-in-out infinite; }
+.hero__visual::after {
+  content: "";
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  bottom: -8px;
+  width: 60%;
+  height: 18px;
+  filter: blur(10px);
+  border-radius: 50%;
+  background: radial-gradient(closest-side, rgba(0, 0, 0, 0.25), transparent);
+  opacity: 0.25;
+  animation: shadowPulse 6s ease-in-out infinite;
+}
 
 @keyframes levitate {
-  0% { transform: translateY(0); }
-  50% { transform: translateY(-10px); }
-  100% { transform: translateY(0); }
+  0% {
+    transform: translateY(0);
+  }
+  50% {
+    transform: translateY(-10px);
+  }
+  100% {
+    transform: translateY(0);
+  }
 }
 @keyframes shadowPulse {
-  0%, 100% { transform: translateX(-50%) scale(1); opacity: 0.25; }
-  50% { transform: translateX(-50%) scale(0.9); opacity: 0.2; }
+  0%,
+  100% {
+    transform: translateX(-50%) scale(1);
+    opacity: 0.25;
+  }
+  50% {
+    transform: translateX(-50%) scale(0.9);
+    opacity: 0.2;
+  }
 }
 
 /* Features */
-.features__list { display: grid; gap: 48px; }
-.feature { display: grid; grid-template-columns: 1fr 1fr; gap: 32px; align-items: center; padding: 24px; border-radius: 24px; border: 1px solid rgba(0,0,0,0.05); position: relative; overflow: hidden; }
-.feature::before { content: ""; position: absolute; inset: 0; background: linear-gradient(135deg, var(--mint), #fff); opacity: 0.7; z-index: 0; }
-.feature--alt::before { background: linear-gradient(135deg, var(--lilac), #fff); }
-.feature:nth-of-type(3)::before { background: linear-gradient(135deg, var(--butter), #fff); }
-.feature:nth-of-type(4)::before { background: linear-gradient(135deg, var(--rose), #fff); }
-.feature:nth-of-type(5)::before { background: linear-gradient(135deg, var(--blue), #fff); }
-.feature > * { position: relative; z-index: 1; }
-.feature__visual img { width: 100%; border-radius: 20px; box-shadow: 0 16px 48px rgba(0,0,0,0.08); }
-.feature__copy h2 { margin: 0 0 8px; font-size: clamp(24px, 3.2vw, 36px); }
-.feature__copy p { margin: 0; color: #333; }
+.features__list {
+  display: grid;
+  gap: 48px;
+}
+.feature {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 32px;
+  align-items: center;
+  padding: 24px;
+  border-radius: 24px;
+  border: 1px solid rgba(0, 0, 0, 0.05);
+  position: relative;
+  overflow: hidden;
+}
+.feature::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(135deg, var(--mint), #fff);
+  opacity: 0.7;
+  z-index: 0;
+}
+.feature--alt::before {
+  background: linear-gradient(135deg, var(--lilac), #fff);
+}
+.feature:nth-of-type(3)::before {
+  background: linear-gradient(135deg, var(--butter), #fff);
+}
+.feature:nth-of-type(4)::before {
+  background: linear-gradient(135deg, var(--rose), #fff);
+}
+.feature:nth-of-type(5)::before {
+  background: linear-gradient(135deg, var(--blue), #fff);
+}
+.feature > * {
+  position: relative;
+  z-index: 1;
+}
+.feature__visual img {
+  width: 100%;
+  border-radius: 20px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.08);
+}
+.feature__copy h2 {
+  margin: 0 0 8px;
+  font-size: clamp(24px, 3.2vw, 36px);
+}
+.feature__copy p {
+  margin: 0;
+  color: #333;
+}
 
 /* Modern feature grid */
-.features--modern .container { background: transparent; box-shadow: none; border: 0; }
-.feature-grid { display: grid; grid-template-columns: repeat(12, minmax(0, 1fr)); gap: 18px; }
-.f-card { position: relative; background: #fff; border: 1px solid rgba(0,0,0,0.06); border-radius: 22px; overflow: hidden; padding: 18px; box-shadow: 0 10px 30px rgba(0,0,0,0.06); display: grid; grid-template-columns: 1.1fr 0.9fr; align-items: center; min-height: 280px; }
-.f-card::before { content: ""; position: absolute; inset: 0; background:
-  radial-gradient(rgba(0,0,0,0.08) 1px, transparent 1px) 0 0/10px 10px;
-  opacity: 0.08; }
-.f-card .f-media img { width: 100%; height: auto; border-radius: 16px; box-shadow: 0 16px 48px rgba(0,0,0,0.08); }
-.f-card .f-body { padding: 8px 10px; }
-.f-card .f-body h3 { margin: 0 0 6px; font-size: clamp(20px, 2.4vw, 28px); }
-.f-card .f-body p { margin: 0; color: #333; }
-.f-card.span-7 { grid-column: span 7; }
-.f-card.span-5 { grid-column: span 5; }
+.features--modern .container {
+  background: transparent;
+  box-shadow: none;
+  border: 0;
+}
+.feature-grid {
+  display: grid;
+  grid-template-columns: repeat(12, minmax(0, 1fr));
+  gap: 18px;
+}
+.f-card {
+  position: relative;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 22px;
+  overflow: hidden;
+  padding: 18px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.06);
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  align-items: center;
+  min-height: 280px;
+}
+.f-card::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(rgba(0, 0, 0, 0.08) 1px, transparent 1px) 0 0/10px
+    10px;
+  opacity: 0.08;
+}
+.f-card .f-media img {
+  width: 100%;
+  height: auto;
+  border-radius: 16px;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.08);
+}
+.f-card .f-body {
+  padding: 8px 10px;
+}
+.f-card .f-body h3 {
+  margin: 0 0 6px;
+  font-size: clamp(20px, 2.4vw, 28px);
+}
+.f-card .f-body p {
+  margin: 0;
+  color: #333;
+}
+.f-card.span-7 {
+  grid-column: span 7;
+}
+.f-card.span-5 {
+  grid-column: span 5;
+}
 
 @media (max-width: 980px) {
-  .feature-grid { grid-template-columns: 1fr; }
-  .f-card { grid-template-columns: 1fr; min-height: 0; }
-  .f-card.span-7, .f-card.span-5 { grid-column: auto; }
+  .feature-grid {
+    grid-template-columns: 1fr;
+  }
+  .f-card {
+    grid-template-columns: 1fr;
+    min-height: 0;
+  }
+  .f-card.span-7,
+  .f-card.span-5 {
+    grid-column: auto;
+  }
 }
 
 /* Download */
-.download__card { background: var(--card); border: 1px solid rgba(0,0,0,0.06); border-radius: 22px; padding: clamp(16px, 3vw, 26px); box-shadow: 0 12px 36px rgba(0,0,0,0.06); text-align: center; }
-.download__card h2 { margin: 0 0 14px; }
-.download__card p { margin: 0; }
-.waitlist-form { display: grid; grid-template-columns: 1fr auto; gap: 10px; margin-top: 16px; }
-.waitlist-form input { font: inherit; padding: 14px 16px; border-radius: 12px; border: 1px solid rgba(0,0,0,0.12); outline: none; min-width: 240px; }
-.waitlist-form input:focus { border-color: var(--brand); box-shadow: 0 0 0 3px rgba(43,216,143,0.2); }
-.form-message { margin-top: 10px; min-height: 24px; }
-.badge { display: inline-flex; margin-top: 16px; padding: 10px 14px; border-radius: 10px; background: #111; color: #fff; text-decoration: none; font-weight: 700; }
-.hero .badge { margin-top: 0; font-size: 16px; padding: 12px 16px; box-shadow: 0 18px 40px rgba(0,0,0,0.18); }
+.download__card {
+  background: var(--card);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 22px;
+  padding: clamp(16px, 3vw, 26px);
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.06);
+  text-align: center;
+}
+.download__card h2 {
+  margin: 0 0 14px;
+}
+.download__card p {
+  margin: 0;
+}
+.waitlist-form {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  margin-top: 16px;
+}
+.waitlist-form input {
+  font: inherit;
+  padding: 14px 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  outline: none;
+  min-width: 240px;
+}
+.waitlist-form input:focus {
+  border-color: var(--brand);
+  box-shadow: 0 0 0 3px rgba(43, 216, 143, 0.2);
+}
+.form-message {
+  margin-top: 10px;
+  min-height: 24px;
+}
+.badge {
+  display: inline-flex;
+  margin-top: 16px;
+  padding: 10px 14px;
+  border-radius: 10px;
+  background: #111;
+  color: #fff;
+  text-decoration: none;
+  font-weight: 700;
+}
+.hero .badge {
+  margin-top: 0;
+  font-size: 16px;
+  padding: 12px 16px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
+}
 
 /* Footer */
-.footer__grid { display: flex; align-items: center; justify-content: space-between; gap: 20px; }
-.footer__links { display: flex; gap: 16px; }
-.footer__links a { color: #e9fff4; text-decoration: none; opacity: 0.9; }
-.footer__links a:hover { opacity: 1; text-decoration: underline; }
+.footer__grid {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+}
+.footer__links {
+  display: flex;
+  gap: 16px;
+}
+.footer__links a {
+  color: #e9fff4;
+  text-decoration: none;
+  opacity: 0.9;
+}
+.footer__links a:hover {
+  opacity: 1;
+  text-decoration: underline;
+}
 
 @media (max-width: 600px) {
-  .footer__grid { flex-direction: column; align-items: flex-start; }
-  .footer__links { flex-wrap: wrap; }
+  .footer__grid {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  .footer__links {
+    flex-wrap: wrap;
+  }
 }
 
 /* Author section */
-.author { background: linear-gradient(135deg, #fff, var(--mint)); }
-.author__grid { display: grid; grid-template-columns: 1.1fr 0.9fr; gap: 28px; align-items: center; }
-.author__text h2 { margin: 0 0 8px; font-size: clamp(26px, 3vw, 36px); }
-.author__text p { margin: 0; color: #333; }
-.socials { margin-top: 10px; display: inline-flex; gap: 10px; flex-wrap: wrap; }
-.socials a { text-decoration: none; color: #0c0d0d; padding: 8px 12px; border-radius: 999px; border: 1px solid rgba(0,0,0,0.12); background: #fff; box-shadow: 0 4px 12px rgba(0,0,0,0.05); font-weight: 600; }
-.socials a:hover { box-shadow: 0 8px 20px rgba(0,0,0,0.08); transform: translateY(-1px); }
-.author__sig { position: relative; padding: 24px; background: #fff; border: 1px solid rgba(0,0,0,0.06); border-radius: 18px; box-shadow: 0 14px 40px rgba(0,0,0,0.08); display: flex; align-items: center; justify-content: center; min-height: 140px; }
-.author__sig::before { content: ""; position: absolute; inset: 12px; border-radius: 14px; background: radial-gradient(500px 120px at 50% 110%, rgba(43,216,143,0.15), transparent); pointer-events: none; }
-.signature { position: relative; font-family: 'Caveat', cursive; font-weight: 700; font-size: clamp(32px, 6vw, 52px); color: #1d1514; letter-spacing: 1px; transform: rotate(-2deg); text-shadow: 0 2px 0 rgba(0,0,0,0.06); }
+.author {
+  background: linear-gradient(135deg, #fff, var(--mint));
+}
+.author__grid {
+  display: grid;
+  grid-template-columns: 1.1fr 0.9fr;
+  gap: 28px;
+  align-items: center;
+}
+.author__text h2 {
+  margin: 0 0 8px;
+  font-size: clamp(26px, 3vw, 36px);
+}
+.author__text p {
+  margin: 0;
+  color: #333;
+}
+.socials {
+  margin-top: 10px;
+  display: inline-flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.socials a {
+  text-decoration: none;
+  color: #0c0d0d;
+  padding: 8px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  background: #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  font-weight: 600;
+}
+.socials a:hover {
+  box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+  transform: translateY(-1px);
+}
+.author__sig {
+  position: relative;
+  padding: 24px;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 18px;
+  box-shadow: 0 14px 40px rgba(0, 0, 0, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 140px;
+}
+.author__sig::before {
+  content: "";
+  position: absolute;
+  inset: 12px;
+  border-radius: 14px;
+  background: radial-gradient(
+    500px 120px at 50% 110%,
+    rgba(43, 216, 143, 0.15),
+    transparent
+  );
+  pointer-events: none;
+}
+.signature {
+  position: relative;
+  font-family: "Caveat", cursive;
+  font-weight: 700;
+  font-size: clamp(32px, 6vw, 52px);
+  color: #1d1514;
+  letter-spacing: 1px;
+  transform: rotate(-2deg);
+  text-shadow: 0 2px 0 rgba(0, 0, 0, 0.06);
+}
 @media (max-width: 900px) {
-  .author__grid { grid-template-columns: 1fr; }
+  .author__grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* Storytelling section */
-.story { background: linear-gradient(180deg, #fff, rgba(255,255,255,0)); }
-.story__stack { display: grid; gap: 16px; }
-.story__card { padding: clamp(14px, 2.6vw, 22px) clamp(16px, 3vw, 26px); border: 1px solid rgba(0,0,0,0.06); border-radius: 18px; background: #fff; box-shadow: 0 8px 24px rgba(0,0,0,0.05); }
-.story__card h2 { margin: 0 0 6px; font-size: clamp(22px, 3vw, 34px); }
-.story__card p { margin: 0; }
-.story__list { margin: 0; padding-left: 1.1em; }
-.story__list li { margin: 4px 0; }
-.story--blue { background: linear-gradient(135deg, #e7f3ff, #fff); }
-.story--sky { background: linear-gradient(135deg, #eaf7ff, #fff); }
-.story--mint { background: linear-gradient(135deg, #eafaea, #fff); }
-.story--butter { background: linear-gradient(135deg, #fff7df, #fff); }
-.story--lilac { background: linear-gradient(135deg, #f1ecff, #fff); }
+.story {
+  background: linear-gradient(180deg, #fff, rgba(255, 255, 255, 0));
+}
+.story__stack {
+  display: grid;
+  gap: 16px;
+}
+.story__card {
+  padding: clamp(14px, 2.6vw, 22px) clamp(16px, 3vw, 26px);
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 18px;
+  background: #fff;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.05);
+}
+.story__card h2 {
+  margin: 0 0 6px;
+  font-size: clamp(22px, 3vw, 34px);
+}
+.story__card p {
+  margin: 0;
+}
+.story__list {
+  margin: 0;
+  padding-left: 1.1em;
+}
+.story__list li {
+  margin: 4px 0;
+}
+.story--blue {
+  background: linear-gradient(135deg, #e7f3ff, #fff);
+}
+.story--sky {
+  background: linear-gradient(135deg, #eaf7ff, #fff);
+}
+.story--mint {
+  background: linear-gradient(135deg, #eafaea, #fff);
+}
+.story--butter {
+  background: linear-gradient(135deg, #fff7df, #fff);
+}
+.story--lilac {
+  background: linear-gradient(135deg, #f1ecff, #fff);
+}
 
 /* Story: plain headline (no card container) */
-.story--plain { background: linear-gradient(135deg, #f7fbff, #fff); }
-.story--plain .story__plain { max-width: 1120px; margin: 0 auto; padding: 0 20px; }
-.story--plain h2 { margin: 0 0 6px; font-size: clamp(28px, 4vw, 46px); }
-.story--plain p { margin: 0; font-size: clamp(16px, 2vw, 18px); }
+.story--plain {
+  background: linear-gradient(135deg, #f7fbff, #fff);
+}
+.story--plain .story__plain {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 0 20px;
+}
+.story--plain h2 {
+  margin: 0 0 6px;
+  font-size: clamp(28px, 4vw, 46px);
+}
+.story--plain p {
+  margin: 0;
+  font-size: clamp(16px, 2vw, 18px);
+}
 
 /* Responsive */
-  @media (max-width: 980px) {
-    .hero__grid { grid-template-columns: 1fr; }
-    .hero__visual { justify-self: center; }
-    .hero__visual img,
-    .hero__visual video { width: min(420px, 100%); height: 58svh; }
+@media (max-width: 980px) {
+  .hero__grid {
+    grid-template-columns: 1fr;
   }
+  .hero__visual {
+    justify-self: center;
+  }
+  .hero__visual img,
+  .hero__visual video {
+    width: min(420px, 100%);
+    height: 58svh;
+  }
+}
 
 @media (max-width: 900px) {
-  .feature { grid-template-columns: 1fr; }
-  .waitlist-form { grid-template-columns: 1fr; }
+  .feature {
+    grid-template-columns: 1fr;
+  }
+  .waitlist-form {
+    grid-template-columns: 1fr;
+  }
 }
 /* Compact header on small screens */
 @media (max-width: 720px) {
-  .nav { padding: 10px 12px; }
-  .brand img { height: 28px; }
-  .nav-cta .btn--ghost, .nav-cta .nav-link { display: none; }
-  .hero { padding: 28px 0 36px; }
-  .hero__card { padding: 16px; }
+  .nav {
+    padding: 10px 12px;
+  }
+  .brand img {
+    height: 28px;
+  }
+  .nav-cta .btn--ghost,
+  .nav-cta .nav-link {
+    display: none;
+  }
+  .hero {
+    padding: 28px 0 36px;
+  }
+  .hero__card {
+    padding: 16px;
+  }
 }
 .how {
-  background: linear-gradient(180deg, #fff, rgba(255,255,255,0));
+  background: linear-gradient(180deg, #fff, rgba(255, 255, 255, 0));
   padding-bottom: 14px;
 }
-.section-title { margin: 0 0 14px; font-size: clamp(28px, 3.4vw, 40px); }
-.section-title--center { text-align: center; }
-.how__card { background: #fff; border: 1px solid rgba(0,0,0,0.06); border-radius: 22px; box-shadow: 0 12px 36px rgba(0,0,0,0.06); padding: clamp(16px, 3vw, 26px); }
-.how__card + .how__card { margin-top: 14px; }
-.how__features { display: grid; gap: 14px; margin-top: 14px; }
-.how__features .how__card + .how__card { margin-top: 0; }
-.how__card--farm { grid-template-columns: 0.9fr 1.1fr; }
-.how__content h3 { margin: 0 0 8px; font-size: clamp(22px, 2.6vw, 28px); }
-.how__steps { margin: 0; padding-left: 1.2em; }
-.how__steps li { margin: 6px 0; }
-.how__media { border: 1px solid rgba(0,0,0,0.06); border-radius: 18px; overflow: hidden; background: linear-gradient(180deg, #f8fbff, #eef8ff); }
-.how__media img, .how__media video { width: 100%; height: 100%; object-fit: cover; display: block; border-radius: 18px; }
-.how__media--wide { aspect-ratio: 16 / 9; }
-.how-video { width: 100%; height: 100%; }
+.section-title {
+  margin: 0 0 14px;
+  font-size: clamp(28px, 3.4vw, 40px);
+}
+.section-title--center {
+  text-align: center;
+}
+.how__card {
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 22px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.06);
+  padding: clamp(16px, 3vw, 26px);
+}
+.how__card + .how__card {
+  margin-top: 14px;
+}
+.how__features {
+  display: grid;
+  gap: 14px;
+  margin-top: 14px;
+}
+.how__features .how__card + .how__card {
+  margin-top: 0;
+}
+.how__card--farm {
+  grid-template-columns: 0.9fr 1.1fr;
+}
+.how__content h3 {
+  margin: 0 0 8px;
+  font-size: clamp(22px, 2.6vw, 28px);
+}
+.how__steps {
+  margin: 0;
+  padding-left: 1.2em;
+}
+.how__steps li {
+  margin: 6px 0;
+}
+.how__media {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 18px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #f8fbff, #eef8ff);
+}
+.how__media img,
+.how__media video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+  border-radius: 18px;
+}
+.how__media--wide {
+  aspect-ratio: 16 / 9;
+}
+.how-video {
+  width: 100%;
+  height: 100%;
+}
 
 @media (max-width: 980px) {
-  .how__media--wide { aspect-ratio: auto; }
+  .how__media--wide {
+    aspect-ratio: auto;
+  }
 }
 
 /* New lightweight How it works layout */
-.how__grid { display: grid; grid-template-columns: 1fr auto; gap: 24px; align-items: center; }
-.steps { list-style: none; margin: 0; padding: 0; display: grid; gap: 12px; }
-.steps li { display: grid; grid-template-columns: auto 1fr; gap: 10px; align-items: center; font-size: clamp(16px, 2.2vw, 20px); color: inherit; }
-.steps .icon { width: 24px; height: 24px; background: none; border-radius: 0; color: inherit; display: inline-grid; place-items: center; }
-.steps .icon svg { width: 100%; height: 100%; display: block; }
-.how__shot { width: clamp(160px, 26vw, 260px); border-radius: 12px; display: block; }
-.how__farmIntro { text-align: center; margin-top: 24px; }
-.how__farmIntro h3 { margin: 0 0 6px; font-size: clamp(22px, 2.6vw, 28px); }
-.how__media { border: 1px solid rgba(0,0,0,0.06); border-radius: 18px; overflow: hidden; background: linear-gradient(180deg, #f8fbff, #eef8ff); margin-top: 10px; }
-.how__media--wide { aspect-ratio: 16 / 9; }
-.how__media video { width: 100%; height: 100%; object-fit: cover; display: block; }
+.how__grid {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 24px;
+  align-items: center;
+}
+.steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 12px;
+}
+.steps li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 10px;
+  align-items: center;
+  font-size: clamp(16px, 2.2vw, 20px);
+  color: inherit;
+}
+.steps .icon {
+  width: 24px;
+  height: 24px;
+  background: none;
+  border-radius: 0;
+  color: inherit;
+  display: inline-grid;
+  place-items: center;
+}
+.steps .icon svg {
+  width: 100%;
+  height: 100%;
+  display: block;
+}
+.how__shot {
+  width: clamp(160px, 26vw, 260px);
+  border-radius: 12px;
+  display: block;
+}
+.how__farmIntro {
+  text-align: center;
+  margin-top: 24px;
+}
+.how__farmIntro h3 {
+  margin: 0 0 6px;
+  font-size: clamp(22px, 2.6vw, 28px);
+}
+.how__media {
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 18px;
+  overflow: hidden;
+  background: linear-gradient(180deg, #f8fbff, #eef8ff);
+  margin-top: 10px;
+}
+.how__media--wide {
+  aspect-ratio: 16 / 9;
+}
+.how__media video {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
 
 @media (max-width: 980px) {
-  .how__grid { grid-template-columns: 1fr; }
-  .how__shot { justify-self: center; }
-  .how__media--wide { aspect-ratio: auto; }
+  .how__grid {
+    grid-template-columns: 1fr;
+  }
+  .how__shot {
+    justify-self: center;
+  }
+  .how__media--wide {
+    aspect-ratio: auto;
+  }
 }
 
 @media (min-width: 768px) {
-  .how__features { grid-template-columns: repeat(2, 1fr); }
+  .how__features {
+    grid-template-columns: repeat(2, 1fr);
+  }
 }
 
 .science {
-  background: linear-gradient(180deg, rgba(255,255,255,0), #fff);
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0), #fff);
   padding-top: 0;
 }
-.science__card { display: grid; grid-template-columns: auto 1fr; gap: 18px; align-items: center; background: #fff; border: 1px solid rgba(0,0,0,0.06); border-radius: 22px; box-shadow: 0 12px 36px rgba(0,0,0,0.06); padding: clamp(16px, 3vw, 26px); }
-.science__content h2 { margin: 0 0 14px; font-size: clamp(22px, 2.6vw, 28px); }
-.science__content p { margin: 0; }
-.science__media img { width: clamp(70px, 12vw, 110px); height: auto; filter: drop-shadow(0 6px 12px rgba(0,0,0,0.1)); }
+.science__card {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 18px;
+  align-items: center;
+  background: #fff;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+  border-radius: 22px;
+  box-shadow: 0 12px 36px rgba(0, 0, 0, 0.06);
+  padding: clamp(16px, 3vw, 26px);
+}
+.science__content h2 {
+  margin: 0 0 14px;
+  font-size: clamp(22px, 2.6vw, 28px);
+}
+.science__content p {
+  margin: 0;
+}
+.science__media img {
+  width: clamp(70px, 12vw, 110px);
+  height: auto;
+  filter: drop-shadow(0 6px 12px rgba(0, 0, 0, 0.1));
+}
 @media (max-width: 900px) {
-  .science__card { grid-template-columns: auto 1fr; text-align: left; }
-  .science__media { order: 0; justify-self: start; }
+  .science__card {
+    grid-template-columns: auto 1fr;
+    text-align: left;
+  }
+  .science__media {
+    order: 0;
+    justify-self: start;
+  }
 }

--- a/styles.css
+++ b/styles.css
@@ -249,7 +249,8 @@ body {
 .how__grid { display: grid; grid-template-columns: 1fr auto; gap: 24px; align-items: center; }
 .steps { list-style: none; margin: 0; padding: 0; display: grid; gap: 12px; }
 .steps li { display: grid; grid-template-columns: auto 1fr; gap: 10px; align-items: center; font-size: clamp(16px, 2.2vw, 20px); color: inherit; }
-.steps .icon { width: auto; height: auto; background: none; border-radius: 0; color: inherit; display: inline-grid; place-items: center; font-size: 22px; font-weight: 700; line-height: 1; }
+.steps .icon { width: 24px; height: 24px; background: none; border-radius: 0; color: inherit; display: inline-grid; place-items: center; }
+.steps .icon svg { width: 100%; height: 100%; display: block; }
 .how__shot { width: clamp(160px, 26vw, 260px); border-radius: 12px; display: block; }
 .how__farmIntro { text-align: center; margin-top: 24px; }
 .how__farmIntro h3 { margin: 0 0 6px; font-size: clamp(22px, 2.6vw, 28px); }


### PR DESCRIPTION
## Summary
- switch onboarding step emojis to matching Lucide SVG icons
- size icons consistently with CSS

## Testing
- `npx prettier -c index.html styles.css` *(fails: Code style issues found)*
- `npx --yes htmlhint index.html`

------
https://chatgpt.com/codex/tasks/task_e_68b5f7b931a4832cb8c605f3e6c295a1