### PR TITLE
Tweak hero video height on mobile and refine ghost button hover effect

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -136,6 +136,11 @@ body {
   color: inherit;
   box-shadow: none;
 }
+
+/* So outline buttons don't drop a colorful shadow */
+.btn--ghost:hover {
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.15);
+}
 .btn--lg {
   padding: 14px 18px;
   font-size: 16px;
@@ -642,7 +647,7 @@ body {
   .hero__visual img,
   .hero__visual video {
     width: min(420px, 100%);
-    height: 58svh;
+    height: 70svh;
   }
 }
 


### PR DESCRIPTION
## Summary
- Increase hero video height on small screens
- Replace colorful hover shadow on outline buttons with a neutral one

## Testing
- `npx prettier --check styles.css index.html script.js`

------
https://chatgpt.com/codex/tasks/task_e_68b6008d0908832c93d14fc764ead480