### PR TITLE
Enlarge header logo and app name

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,7 +67,7 @@
     <header class="site-header">
       <nav class="nav">
         <a class="brand" href="#top" aria-label="Time Farm home">
-          <img src="assets/logo/logo_5_dark_transparant.png" alt="Time Farm logo" height="28" style="display:inline-block"/>
+          <img src="assets/logo/logo_5_dark_transparant.png" alt="Time Farm logo" height="48" style="display:inline-block"/>
           <span>Time Farm</span>
         </a>
         <div class="nav-cta">

--- a/styles.css
+++ b/styles.css
@@ -76,13 +76,13 @@ body {
   text-decoration: none;
   color: inherit;
   font-weight: 800;
-  font-size: clamp(20px, 2.2vw, 26px);
+  font-size: clamp(30px, 3.3vw, 39px);
 }
 .brand-mark {
   font-size: 20px;
 }
 .brand img {
-  height: clamp(32px, 3.2vw, 40px);
+  height: clamp(48px, 4.8vw, 60px);
   width: auto;
 }
 .nav-cta {


### PR DESCRIPTION
## Summary
- Increase header brand text size by 1.5×
- Upscale the header logo image to match

## Testing
- `npm test` *(fails: ENOENT cannot find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6076b3000832cb69a85a00d6ae074