### PR TITLE
feat: dynamic header Get App link

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
         <div class="nav-cta">
           <a class="btn btn--ghost" href="https://productive-lab.com/time-farm/support" target="_blank" rel="noopener">Support</a>
           <a class="btn btn--ghost" href="https://productive-lab.com" target="_blank" rel="noopener">Other apps</a>
-          <a class="btn btn--dark" href="#download">Get the App</a>
+          <a class="btn btn--dark" id="getAppButton" href="#download">Get the App</a>
         </div>
       </nav>
     </header>

--- a/script.js
+++ b/script.js
@@ -11,6 +11,21 @@ document.querySelectorAll('a[href^="#"]').forEach((a) => {
   });
 });
 
+// Header Get the App button: link directly to the store if it's the only option
+(() => {
+  const btn = document.getElementById('getAppButton');
+  if (!btn) return;
+  const stores = document.querySelectorAll('.store-badges a');
+  if (stores.length === 1) {
+    const href = stores[0].getAttribute('href');
+    if (href) {
+      btn.href = href;
+      btn.target = '_blank';
+      btn.rel = 'noopener';
+    }
+  }
+})();
+
 // Simple waitlist form UX (local-only)
 const form = document.getElementById('waitlist');
 const msg = document.getElementById('formMessage');


### PR DESCRIPTION
## Summary
- Link header "Get the App" button directly to the store when only one store is available
- Add script to update the button based on number of store badges

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b724f31048832cb887f5f590177a08